### PR TITLE
Configure default font in Tailwind

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -56,7 +56,8 @@ npm run build
 npm run preview
 ```
 
-O arquivo [`tailwind.config.ts`](../../tailwind.config.ts) define os caminhos de fontes do Tailwind.
+O arquivo [`tailwind.config.ts`](../../tailwind.config.ts) define os caminhos de fontes do Tailwind e a família padrão utilizada pela aplicação.
+Atualmente, a fonte **Inter** é configurada em `fontFamily.sans`, permitindo o uso das classes `font-sans` em todo o projeto.
 Mais detalhes sobre as cores e variáveis utilizadas estão em [`tailwind-theme.md`](./tailwind-theme.md).
 
 ## Notas da versão (Changelog)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,8 +18,8 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
@@ -59,18 +59,28 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
-			borderRadius: {
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
+                                        'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+                                        accent: 'hsl(var(--sidebar-accent))',
+                                        'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+                                        border: 'hsl(var(--sidebar-border))',
+                                        ring: 'hsl(var(--sidebar-ring))'
+                                }
+                        },
+                        fontFamily: {
+                                sans: [
+                                        'Inter',
+                                        '-apple-system',
+                                        'BlinkMacSystemFont',
+                                        '"Segoe UI"',
+                                        'Roboto',
+                                        'sans-serif'
+                                ]
+                        },
+                        borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'


### PR DESCRIPTION
## Summary
- configure `fontFamily.sans` with Inter
- document the new font configuration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68628a11a2048325a6105804eadbd33c