### PR TITLE
Add onboarding screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,10 @@ import AIValidator from "./pages/AIValidator";
 import HeatmapAI from "./pages/HeatmapAI";
 import DynamicPricing from "./pages/DynamicPricing";
 import LegalAI from "./pages/LegalAI";
+import UserOnboarding from "./pages/UserOnboarding";
+import TenantOnboarding from "./pages/TenantOnboarding";
+import TenantDashboard from "./pages/TenantDashboard";
+import PlanSelectionPage from "./pages/PlanSelection";
 import Teste from './pages/Test';
 
 const queryClient = new QueryClient();
@@ -64,6 +68,9 @@ const App = () => (
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/data-test" element={<Teste />} />
           <Route path="/plans" element={<Plans />} />
+          <Route path="/onboarding/user" element={<UserOnboarding />} />
+          <Route path="/onboarding/tenant" element={<TenantOnboarding />} />
+          <Route path="/onboarding/plan" element={<PlanSelectionPage />} />
           <Route
             path="/dashboard"
             element={
@@ -72,6 +79,7 @@ const App = () => (
               </PrivateRoute>
             }
           />
+          <Route path="/tenant-dashboard" element={<PrivateRoute><TenantDashboard /></PrivateRoute>} />
           <Route path="/events" element={<Events />} />
           <Route path="/events/new" element={<NewEvent />} />
           <Route path="/exhibitors" element={<Exhibitors />} />

--- a/src/components/modals/InviteModal.tsx
+++ b/src/components/modals/InviteModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter, DialogClose } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const inviteSchema = z.object({
+  email: z.string().email('Email inválido'),
+})
+
+interface InviteForm extends z.infer<typeof inviteSchema> {}
+
+const InviteModal: React.FC = () => {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<InviteForm>({ resolver: zodResolver(inviteSchema) })
+
+  const onSubmit = (data: InviteForm) => {
+    console.log('Convidar', data)
+    reset()
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Convidar usuário</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Enviar Convite</DialogTitle>
+          </DialogHeader>
+          <div>
+            <label htmlFor="invite" className="block text-sm font-medium mb-1">Email</label>
+            <Input id="invite" type="email" {...register('email')} />
+            {errors.email && <p className="text-sm text-destructive mt-1">{errors.email.message}</p>}
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">Cancelar</Button>
+            </DialogClose>
+            <Button type="submit">Enviar</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default InviteModal

--- a/src/pages/PlanSelection.tsx
+++ b/src/pages/PlanSelection.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+interface PlanForm {
+  plan: 'basic' | 'pro' | 'enterprise'
+  billing: 'monthly' | 'annual'
+}
+
+const PlanSelection: React.FC = () => {
+  const { register, handleSubmit, watch } = useForm<PlanForm>({
+    defaultValues: { billing: 'monthly' },
+  })
+
+  const onSubmit = (data: PlanForm) => {
+    console.log('Plano escolhido', data)
+  }
+
+  const billing = watch('billing')
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-background">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="w-full max-w-md space-y-6 bg-card p-6 rounded-lg shadow-card"
+      >
+        <h1 className="text-2xl font-bold">Seleção de Plano</h1>
+
+        {/* Toggle mensal/anual */}
+        <div className="flex gap-2">
+          <label className="flex items-center gap-2">
+            <input type="radio" value="monthly" {...register('billing')} /> Mensal
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" value="annual" {...register('billing')} /> Anual
+          </label>
+        </div>
+
+        {/* Planos disponíveis */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2">
+            <input type="radio" value="basic" {...register('plan', { required: true })} />
+            Básico {billing === 'annual' ? 'R$100/ano' : 'R$10/mês'}
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" value="pro" {...register('plan', { required: true })} />
+            Pro {billing === 'annual' ? 'R$200/ano' : 'R$20/mês'}
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" value="enterprise" {...register('plan', { required: true })} />
+            Enterprise
+          </label>
+        </div>
+
+        <Button type="submit" className="w-full">
+          Continuar
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+export default PlanSelection

--- a/src/pages/TenantDashboard.tsx
+++ b/src/pages/TenantDashboard.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import DashboardLayout from '@/components/layout/Dashboard'
+import { useAuth } from '@/context/AuthContext'
+import InviteModal from '@/components/modals/InviteModal'
+
+const TenantDashboard: React.FC = () => {
+  // Obtém tenant do contexto de autenticação
+  const { tenant } = useAuth()
+
+  return (
+    <DashboardLayout title="Dashboard">
+      <div className="space-y-4">
+        <h2 className="text-2xl font-semibold">Bem-vindo</h2>
+        {tenant ? (
+          <p className="text-muted-foreground">Dados filtrados para o tenant: {tenant.id}</p>
+        ) : (
+          <p className="text-muted-foreground">Nenhum tenant selecionado</p>
+        )}
+        {/* Modal de convite de usuário */}
+        <InviteModal />
+      </div>
+    </DashboardLayout>
+  )
+}
+
+export default TenantDashboard

--- a/src/pages/TenantOnboarding.tsx
+++ b/src/pages/TenantOnboarding.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import type { Tenant } from '@/context/AuthContext'
+
+// Esquema básico para cadastro de tenant
+const tenantSchema = z.object({
+  razao_social: z.string().min(1, 'Razão social é obrigatória'),
+  nome_fantasia: z.string().optional(),
+  cnpj: z.string().min(14, 'CNPJ inválido'),
+  contact_email: z.string().email('Email inválido'),
+})
+
+type TenantFormValues = z.infer<typeof tenantSchema>
+
+const TenantOnboarding: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TenantFormValues>({ resolver: zodResolver(tenantSchema) })
+
+  const onSubmit = (data: TenantFormValues) => {
+    const tenant: Partial<Tenant> = {
+      razao_social: data.razao_social,
+      nome_fantasia: data.nome_fantasia || '',
+      cnpj: data.cnpj,
+      contact_email: data.contact_email,
+    }
+    // Envio para API ou contexto
+    console.log('Novo tenant', tenant)
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-background">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="w-full max-w-lg space-y-4 bg-card p-6 rounded-lg shadow-card"
+      >
+        <h1 className="text-2xl font-bold mb-2">Cadastro de Empresa</h1>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="razao">
+            Razão Social
+          </label>
+          <Input id="razao" {...register('razao_social')} />
+          {errors.razao_social && (
+            <p className="text-sm text-destructive mt-1">{errors.razao_social.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="fantasia">
+            Nome Fantasia
+          </label>
+          <Input id="fantasia" {...register('nome_fantasia')} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="cnpj">
+            CNPJ
+          </label>
+          <Input id="cnpj" {...register('cnpj')} placeholder="00.000.000/0000-00" />
+          {errors.cnpj && <p className="text-sm text-destructive mt-1">{errors.cnpj.message}</p>}
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="contactEmail">
+            Email de Contato
+          </label>
+          <Input id="contactEmail" type="email" {...register('contact_email')} />
+          {errors.contact_email && (
+            <p className="text-sm text-destructive mt-1">{errors.contact_email.message}</p>
+          )}
+        </div>
+        <Button type="submit" className="w-full">
+          Salvar Empresa
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+export default TenantOnboarding

--- a/src/pages/UserOnboarding.tsx
+++ b/src/pages/UserOnboarding.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+// Schema de validação usando Zod para garantir regras de negócio
+const userSchema = z.object({
+  firstName: z.string().min(1, 'Nome é obrigatório'),
+  lastName: z.string().min(1, 'Sobrenome é obrigatório'),
+  email: z.string().email('Email inválido'),
+  password: z
+    .string()
+    .min(8, 'Mínimo 8 caracteres')
+    .regex(/\d/, 'Deve conter número')
+    .regex(/[^A-Za-z0-9]/, 'Deve conter caractere especial'),
+  whatsapp: z
+    .string()
+    .regex(/^\+[1-9]\d{1,14}$/, 'Formato E.164 obrigatório'),
+})
+
+type UserFormValues = z.infer<typeof userSchema>
+
+const UserOnboarding: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormValues>({ resolver: zodResolver(userSchema) })
+
+  const onSubmit = (data: UserFormValues) => {
+    // Aqui enviaríamos os dados para a API
+    console.log('Novo usuário', data)
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-background">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="w-full max-w-md space-y-4 bg-card p-6 rounded-lg shadow-card"
+      >
+        <h1 className="text-2xl font-bold mb-2">Cadastro de Usuário</h1>
+        {/* Campo nome */}
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="firstName">
+            Nome
+          </label>
+          <Input id="firstName" {...register('firstName')} />
+          {errors.firstName && (
+            <p className="text-sm text-destructive mt-1">{errors.firstName.message}</p>
+          )}
+        </div>
+        {/* Campo sobrenome */}
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="lastName">
+            Sobrenome
+          </label>
+          <Input id="lastName" {...register('lastName')} />
+          {errors.lastName && (
+            <p className="text-sm text-destructive mt-1">{errors.lastName.message}</p>
+          )}
+        </div>
+        {/* Email */}
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="email">
+            Email
+          </label>
+          <Input id="email" type="email" {...register('email')} />
+          {errors.email && <p className="text-sm text-destructive mt-1">{errors.email.message}</p>}
+        </div>
+        {/* Senha com requisitos */}
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="password">
+            Senha
+          </label>
+          <Input id="password" type="password" {...register('password')} />
+          {errors.password && (
+            <p className="text-sm text-destructive mt-1">{errors.password.message}</p>
+          )}
+        </div>
+        {/* WhatsApp no padrão E.164 */}
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="whatsapp">
+            WhatsApp
+          </label>
+          <Input id="whatsapp" placeholder="+5511999999999" {...register('whatsapp')} />
+          {errors.whatsapp && (
+            <p className="text-sm text-destructive mt-1">{errors.whatsapp.message}</p>
+          )}
+        </div>
+        <Button type="submit" className="w-full">
+          Cadastrar
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+export default UserOnboarding


### PR DESCRIPTION
## Summary
- add user onboarding screen with password rules
- add tenant onboarding form using Tenant interface
- add simple plan selection form
- add invite modal with email validation
- add tenant dashboard page
- wire new routes into App router

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b76490d0083258a5397a1b209f0e9