### PR TITLE
Add UI screens for registration and plans

### DIFF
--- a/src/features/common/InputField.tsx
+++ b/src/features/common/InputField.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+/**
+ * Componente reutilizável para campos de formulário com label
+ */
+export interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string
+  error?: string
+}
+
+const InputField: React.FC<InputFieldProps> = ({ label, error, className, id, ...props }) => (
+  <div className="space-y-1">
+    <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+      {label}
+    </label>
+    <Input id={id} className={cn(className, error && 'border-destructive')} {...props} />
+    {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+  </div>
+)
+
+export default InputField

--- a/src/features/magicLinkInvite/MagicLinkInvite.tsx
+++ b/src/features/magicLinkInvite/MagicLinkInvite.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import InputField from '../common/InputField'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Geração de link mágico para convidar usuários
+ */
+export interface MagicLinkInviteProps {
+  onGenerate?: (email: string) => void
+}
+
+const MagicLinkInvite: React.FC<MagicLinkInviteProps> = ({ onGenerate }) => {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!/^\S+@\S+\.\S+$/.test(email)) {
+      setError('Email inválido')
+      return
+    }
+    setError('')
+    onGenerate?.(email)
+    console.log('Gerar link mágico para', email)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
+      <InputField
+        id="magic-email"
+        label="Email do Convidado"
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        error={error}
+        required
+      />
+      <Button type="submit" className="w-full">
+        Gerar link mágico
+      </Button>
+    </form>
+  )
+}
+
+export default MagicLinkInvite

--- a/src/features/planSelection/PlanSelection.tsx
+++ b/src/features/planSelection/PlanSelection.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Seleção de plano de assinatura com dados fictícios
+ */
+export interface Plan {
+  id: string
+  name: string
+  price: string
+  features: string[]
+}
+
+export interface PlanSelectionProps {
+  plans?: Plan[]
+  onSelect?: (planId: string) => void
+}
+
+const defaultPlans: Plan[] = [
+  { id: 'basic', name: 'Básico', price: 'R$ 49/mês', features: ['1 evento', 'Suporte básico'] },
+  { id: 'pro', name: 'Pro', price: 'R$ 99/mês', features: ['5 eventos', 'Suporte prioritário'] },
+  { id: 'enterprise', name: 'Enterprise', price: 'Sob consulta', features: ['Eventos ilimitados', 'Suporte dedicado'] }
+]
+
+const PlanSelection: React.FC<PlanSelectionProps> = ({ plans = defaultPlans, onSelect }) => {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {plans.map(plan => (
+        <div key={plan.id} className="border rounded-lg p-4 bg-card flex flex-col">
+          <h3 className="text-lg font-semibold mb-1">{plan.name}</h3>
+          <p className="text-2xl font-bold mb-2">{plan.price}</p>
+          <ul className="flex-1 text-sm list-disc list-inside mb-4 space-y-1">
+            {plan.features.map(feature => (
+              <li key={feature}>{feature}</li>
+            ))}
+          </ul>
+          <Button onClick={() => onSelect?.(plan.id)}>Selecionar</Button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default PlanSelection

--- a/src/features/tenantDashboard/TenantDashboard.tsx
+++ b/src/features/tenantDashboard/TenantDashboard.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+/**
+ * Lista de dados da empresa filtrados por tenant_id (dados fictícios)
+ */
+export interface TenantDashboardProps {
+  tenantId: string
+}
+
+interface DataItem {
+  id: number
+  name: string
+  value: string
+}
+
+const sampleData: DataItem[] = [
+  { id: 1, name: 'Eventos', value: '3' },
+  { id: 2, name: 'Usuários', value: '12' },
+  { id: 3, name: 'Visitantes', value: '150' }
+]
+
+const TenantDashboard: React.FC<TenantDashboardProps> = ({ tenantId }) => {
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-4">Dashboard da Empresa</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Dados filtrados para tenant: <strong>{tenantId}</strong>
+      </p>
+      <table className="w-full text-sm border">
+        <thead className="bg-muted">
+          <tr>
+            <th className="p-2 text-left">Nome</th>
+            <th className="p-2 text-left">Valor</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sampleData.map(item => (
+            <tr key={item.id} className="border-t">
+              <td className="p-2">{item.name}</td>
+              <td className="p-2">{item.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default TenantDashboard

--- a/src/features/tenantRegistration/TenantRegistration.tsx
+++ b/src/features/tenantRegistration/TenantRegistration.tsx
@@ -1,0 +1,227 @@
+import React, { useState } from 'react'
+import InputField from '../common/InputField'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Tela de cadastro de empresa (tenant)
+ */
+export interface TenantData {
+  razaoSocial: string
+  cnpj: string
+  cnaePrincipal?: string
+  contactEmail: string
+  contactPhone?: string
+  cep: string
+  enderecoLogradouro: string
+  enderecoNumero?: string
+  enderecoBairro: string
+  enderecoCidade: string
+  slug: string
+  organizerTypeId: string
+  planId: string
+  primarySegmentId: string
+  stateId: string
+  statusId: string
+  billingCnpj?: string
+  billingEmail?: string
+}
+
+export interface TenantRegistrationProps {
+  onSubmit?: (data: TenantData) => void
+}
+
+const TenantRegistration: React.FC<TenantRegistrationProps> = ({ onSubmit }) => {
+  const [data, setData] = useState<TenantData>({
+    razaoSocial: '',
+    cnpj: '',
+    cnaePrincipal: '',
+    contactEmail: '',
+    contactPhone: '',
+    cep: '',
+    enderecoLogradouro: '',
+    enderecoNumero: '',
+    enderecoBairro: '',
+    enderecoCidade: '',
+    slug: '',
+    organizerTypeId: '',
+    planId: '',
+    primarySegmentId: '',
+    stateId: '',
+    statusId: '',
+    billingCnpj: '',
+    billingEmail: ''
+  })
+
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const handleChange = (field: keyof TenantData, value: string) => {
+    setData(prev => ({ ...prev, [field]: value }))
+  }
+
+  const validate = () => {
+    const errs: Record<string, string> = {}
+    if (!/^\d{14}$/.test(data.cnpj.replace(/\D/g, ''))) {
+      errs.cnpj = 'CNPJ inválido'
+    }
+    if (!/^\S+@\S+\.\S+$/.test(data.contactEmail)) {
+      errs.contactEmail = 'Email inválido'
+    }
+    if (data.contactPhone && !/^\+?\d{10,15}$/.test(data.contactPhone)) {
+      errs.contactPhone = 'Telefone inválido'
+    }
+    if (!/^\d{5}-?\d{3}$/.test(data.cep)) {
+      errs.cep = 'CEP inválido'
+    }
+    return errs
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const v = validate()
+    setErrors(v)
+    if (Object.keys(v).length === 0) {
+      onSubmit?.(data)
+      console.log('Empresa cadastrada', data)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 bg-card p-6 rounded-md max-w-2xl mx-auto"
+    >
+      <InputField
+        id="razaoSocial"
+        label="Razão Social"
+        value={data.razaoSocial}
+        onChange={e => handleChange('razaoSocial', e.target.value)}
+        required
+      />
+      <InputField
+        id="cnpj"
+        label="CNPJ"
+        value={data.cnpj}
+        onChange={e => handleChange('cnpj', e.target.value)}
+        error={errors.cnpj}
+        required
+      />
+      <InputField
+        id="cnaePrincipal"
+        label="CNAE Principal"
+        value={data.cnaePrincipal}
+        onChange={e => handleChange('cnaePrincipal', e.target.value)}
+      />
+      <InputField
+        id="contactEmail"
+        label="Email de Contato"
+        type="email"
+        value={data.contactEmail}
+        onChange={e => handleChange('contactEmail', e.target.value)}
+        error={errors.contactEmail}
+        required
+      />
+      <InputField
+        id="contactPhone"
+        label="Telefone"
+        value={data.contactPhone}
+        onChange={e => handleChange('contactPhone', e.target.value)}
+        error={errors.contactPhone}
+      />
+      <InputField
+        id="cep"
+        label="CEP"
+        value={data.cep}
+        onChange={e => handleChange('cep', e.target.value)}
+        error={errors.cep}
+        required
+      />
+      <InputField
+        id="enderecoLogradouro"
+        label="Logradouro"
+        value={data.enderecoLogradouro}
+        onChange={e => handleChange('enderecoLogradouro', e.target.value)}
+        required
+      />
+      <InputField
+        id="enderecoNumero"
+        label="Número"
+        value={data.enderecoNumero}
+        onChange={e => handleChange('enderecoNumero', e.target.value)}
+      />
+      <InputField
+        id="enderecoBairro"
+        label="Bairro"
+        value={data.enderecoBairro}
+        onChange={e => handleChange('enderecoBairro', e.target.value)}
+        required
+      />
+      <InputField
+        id="enderecoCidade"
+        label="Cidade"
+        value={data.enderecoCidade}
+        onChange={e => handleChange('enderecoCidade', e.target.value)}
+        required
+      />
+      <InputField
+        id="slug"
+        label="Slug"
+        value={data.slug}
+        onChange={e => handleChange('slug', e.target.value)}
+        required
+      />
+      <InputField
+        id="organizerTypeId"
+        label="Organizer Type ID"
+        value={data.organizerTypeId}
+        onChange={e => handleChange('organizerTypeId', e.target.value)}
+        required
+      />
+      <InputField
+        id="planId"
+        label="Plan ID"
+        value={data.planId}
+        onChange={e => handleChange('planId', e.target.value)}
+        required
+      />
+      <InputField
+        id="primarySegmentId"
+        label="Segmento Principal"
+        value={data.primarySegmentId}
+        onChange={e => handleChange('primarySegmentId', e.target.value)}
+        required
+      />
+      <InputField
+        id="stateId"
+        label="Estado"
+        value={data.stateId}
+        onChange={e => handleChange('stateId', e.target.value)}
+        required
+      />
+      <InputField
+        id="statusId"
+        label="Status ID"
+        value={data.statusId}
+        onChange={e => handleChange('statusId', e.target.value)}
+        required
+      />
+      <InputField
+        id="billingCnpj"
+        label="CNPJ de Cobrança"
+        value={data.billingCnpj}
+        onChange={e => handleChange('billingCnpj', e.target.value)}
+      />
+      <InputField
+        id="billingEmail"
+        label="Email de Cobrança"
+        type="email"
+        value={data.billingEmail}
+        onChange={e => handleChange('billingEmail', e.target.value)}
+      />
+      <Button type="submit" className="w-full">
+        Cadastrar Empresa
+      </Button>
+    </form>
+  )
+}
+
+export default TenantRegistration

--- a/src/features/userRegistration/UserRegistration.tsx
+++ b/src/features/userRegistration/UserRegistration.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react'
+import InputField from '../common/InputField'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Tela de cadastro de usuário
+ */
+export interface UserData {
+  firstName: string
+  lastName: string
+  email: string
+  password: string
+  whatsapp: string
+}
+
+export interface UserRegistrationProps {
+  onSubmit?: (data: UserData) => void
+}
+
+const UserRegistration: React.FC<UserRegistrationProps> = ({ onSubmit }) => {
+  const [data, setData] = useState<UserData>({
+    firstName: '',
+    lastName: '',
+    email: '',
+    password: '',
+    whatsapp: ''
+  })
+
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const handleChange = (field: keyof UserData, value: string) => {
+    setData(prev => ({ ...prev, [field]: value }))
+  }
+
+  const validate = () => {
+    const errs: Record<string, string> = {}
+    if (!/^\S+@\S+\.\S+$/.test(data.email)) {
+      errs.email = 'Email inválido'
+    }
+    if (data.password.length < 6) {
+      errs.password = 'Mínimo 6 caracteres'
+    }
+    if (data.whatsapp && !/^\+?\d{10,15}$/.test(data.whatsapp)) {
+      errs.whatsapp = 'Telefone inválido'
+    }
+    return errs
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const v = validate()
+    setErrors(v)
+    if (Object.keys(v).length === 0) {
+      onSubmit?.(data)
+      // Apenas log para fins de demonstração
+      console.log('Usuário cadastrado', data)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 bg-card p-6 rounded-md max-w-md mx-auto"
+    >
+      <InputField
+        id="firstName"
+        label="Primeiro Nome"
+        value={data.firstName}
+        onChange={e => handleChange('firstName', e.target.value)}
+        required
+      />
+      <InputField
+        id="lastName"
+        label="Sobrenome"
+        value={data.lastName}
+        onChange={e => handleChange('lastName', e.target.value)}
+        required
+      />
+      <InputField
+        id="email"
+        label="Email"
+        type="email"
+        value={data.email}
+        onChange={e => handleChange('email', e.target.value)}
+        error={errors.email}
+        required
+      />
+      <InputField
+        id="password"
+        label="Senha"
+        type="password"
+        value={data.password}
+        onChange={e => handleChange('password', e.target.value)}
+        error={errors.password}
+        required
+      />
+      <InputField
+        id="whatsapp"
+        label="WhatsApp"
+        placeholder="(00) 90000-0000"
+        value={data.whatsapp}
+        onChange={e => handleChange('whatsapp', e.target.value)}
+        error={errors.whatsapp}
+      />
+      <Button type="submit" className="w-full">
+        Cadastrar
+      </Button>
+    </form>
+  )
+}
+
+export default UserRegistration


### PR DESCRIPTION
## Summary
- add reusable `InputField` component
- create `UserRegistration` page
- create `TenantRegistration` page
- create `TenantDashboard` placeholder table
- add `PlanSelection` cards
- add `MagicLinkInvite` form

## Testing
- `npm run lint` *(fails: unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688b78ce2f8083258967f89803bbe758