### PR TITLE
feat(invites): add invites table and integrate onboarding hooks

### DIFF
--- a/src/features/InviteOnboarding/types/invite.types.ts
+++ b/src/features/InviteOnboarding/types/invite.types.ts
@@ -1,15 +1,15 @@
 
 export interface InviteData {
   id: string
-  email: string
   tenant_id: string
-  role: 'staff' | 'manager' | 'admin'
+  email: string
+  role: string
+  token: string
   status: 'pending' | 'accepted' | 'revoked' | 'expired'
   expires_at: string
-  invited_by: string
-  created_at: string
-  accepted_at?: string
-  revoked_at?: string
+  invited_by: string | null
+  created_at: string | null
+  accepted_at?: string | null
 }
 
 export interface TenantBranding {

--- a/supabase/migrations/20250806192000_add_indexes_on_invitations.sql
+++ b/supabase/migrations/20250806192000_add_indexes_on_invitations.sql
@@ -1,0 +1,15 @@
+-- Migration: 20250806192000_add_indexes_on_invitations.sql
+-- Table: invitations
+-- Description: Adiciona índices para consultas frequentes na tabela invitations.
+-- Author: OpenAI ChatGPT
+-- Date: 2025-08-06
+
+BEGIN;
+  CREATE INDEX idx_invitations_tenant_status ON public.invitations(tenant_id, status);
+  CREATE INDEX idx_invitations_email ON public.invitations(email);
+COMMIT;
+
+-- ROLLBACK
+-- DROP INDEX IF EXISTS public.idx_invitations_email;
+-- DROP INDEX IF EXISTS public.idx_invitations_tenant_status;
+-- COMMIT;

--- a/supabase/migrations/20250806193000_create_table_invites.sql
+++ b/supabase/migrations/20250806193000_create_table_invites.sql
@@ -1,0 +1,29 @@
+-- Migration: 20250806193000_create_table_invites.sql
+-- Table: invites
+-- Description: Cria tabela de convites para fluxo de magic link com índices de apoio.
+-- Author: OpenAI ChatGPT
+-- Date: 2025-08-06
+
+BEGIN;
+  CREATE TABLE public.invites (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid REFERENCES public.tenants(id) ON DELETE CASCADE,
+    email text NOT NULL,
+    role uuid REFERENCES public.user_roles(id) NOT NULL,
+    token text UNIQUE NOT NULL,
+    status text CHECK (status IN ('pending','accepted','revoked','expired')) DEFAULT 'pending',
+    expires_at timestamptz NOT NULL,
+    invited_by uuid REFERENCES public.profiles(id),
+    accepted_at timestamptz,
+    created_at timestamptz DEFAULT now()
+  );
+
+  CREATE INDEX idx_invites_tenant_status ON public.invites(tenant_id, status);
+  CREATE INDEX idx_invites_email ON public.invites(email);
+COMMIT;
+
+-- ROLLBACK
+-- DROP INDEX IF EXISTS public.idx_invites_email;
+-- DROP INDEX IF EXISTS public.idx_invites_tenant_status;
+-- DROP TABLE IF EXISTS public.invites;
+-- COMMIT;


### PR DESCRIPTION
## Summary
- create invites table with indexes and add missing invitations indexes
- wire invite validation and acceptance hooks to Supabase
- expand invite types to include token and metadata

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a5098f048325a5c3bb349a56b643